### PR TITLE
Memoize current user to prevent queries

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -17,18 +17,17 @@ module SessionsHelper
 
   # Returns the user corresponding to the remember token cookie.
   def current_user
-    if (user_id = session[:user_id])
-      user = User.find_by(id: user_id)
-      if user && session[:session_token] == user.session_token
-        @current_user = user
+    @current_user ||=
+      if (user_id = session[:user_id])
+        user = User.find_by(id: user_id)
+        user if session[:session_token] == user&.session_token
+      elsif (user_id = cookies.encrypted[:user_id])
+        user = User.find_by(id: user_id)
+        if user&.authenticated?(:remember, cookies[:remember_token])
+          log_in user
+          user
+        end
       end
-    elsif (user_id = cookies.encrypted[:user_id])
-      user = User.find_by(id: user_id)
-      if user && user.authenticated?(:remember, cookies[:remember_token])
-        log_in user
-        @current_user = user
-      end
-    end
   end
 
   # Returns true if the given user is the current user.

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -16,4 +16,13 @@ class SessionsHelperTest < ActionView::TestCase
     @user.update_attribute(:remember_digest, User.digest(User.new_token))
     assert_nil current_user
   end
+
+  test "user isn't queried twice in the database" do
+    ActiveRecord::Base.uncached do
+      current_user
+      assert_queries_count(0) do
+        current_user
+      end
+    end
+  end
 end


### PR DESCRIPTION
Memoization was removed with the fix for session replay attack.

In development, it can be seen in Rails logs that the database is queried multiple times. However, in tests, we need `ActiveRecord::Base.uncached` to reproduce the multiple queries.